### PR TITLE
fixed wrong OS version and several package conflicts 

### DIFF
--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.3-apache-stretch
 
 RUN apt-get -y update --fix-missing
 RUN apt-get upgrade -y


### PR DESCRIPTION
the main image seems to use buster now. This creates several package conflicts during the build. With fixed debian stretch version everything work's fine now. 
