### PR TITLE
Fixed Web-Server Build Error "libcurl3 has no installation candidate"

### DIFF
--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -1,10 +1,18 @@
-FROM php:7.2-apache
+#Quickfix - Basebox for PHP7.2 Library now uses Debian "10" Buster, superceeding #libcurl3, stretch is most compatible at this time whilst devs workout backport.
+#https://github.com/docker-library/php/issues/865
 
-RUN apt-get -y update --fix-missing
-RUN apt-get upgrade -y
+FROM php:7.2-apache-stretch
+
+#Surpresses debconf complaints of trying to install apt packages interactively
+#https://github.com/moby/moby/issues/4032#issuecomment-192327844
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update --fix-missing --no-install-recommends
+RUN apt-get -y upgrade
 
 # Install useful tools
-RUN apt-get -y install apt-utils nano wget dialog
+RUN apt-get -yq install apt-utils nano wget dialog
 
 # Install important libraries
 RUN apt-get -y install --fix-missing apt-utils build-essential git curl libcurl3 libcurl3-dev zip openssl


### PR DESCRIPTION
Webserver fails to build because the basebox for PHP 7.2's dockerfile now uses Debian "10" or "Buster", superseding libcurl3 with libcurl4.

Additionally, I have set the Debian package manager dpkg to "noninteractive" to suppress dpkg complaints of interactivity when installing. This is passed as an ARG in the Dockerfile rather then ENV as per best-practice.

Webserver: https://github.com/docker-library/php/issues/865
Supressing DPKG https://github.com/moby/moby/issues/4032#issuecomment-192327844

(First ever PR, so please forgive me!)