### PR TITLE
7.3.x reduce docker image size introduce mariadb env switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ docker exec -it 7.3.x-webserver /bin/bash
 
 ## Database
 
-This will be used to choose the Database vendor. MySQL is used by default.
+There are following configuration variables available and you can customize them by overwritting in your own .env file.
 
 _**DATABASE**_
+
+Switch the database vendor from mysql to mariadb. You can also easily add additonal database versions. 
 
 ## PHP
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ By default following modules are enabled.
 > If you want to enable more modules, just update `./bin/webserver/Dockerfile`. You can also generate a PR and we will merge if seems good for general purpose.
 > You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
 
-## Database
-
-This will be used to choose the Database vendor. MySQL is used by default.
-
-_**DATABASE**_
-
 #### Connect via SSH
 
 You can connect to web server using `docker exec` command to perform various operation on it. Use below command to login to container via ssh.
@@ -80,6 +74,12 @@ You can connect to web server using `docker exec` command to perform various ope
 ```shell
 docker exec -it 7.3.x-webserver /bin/bash
 ```
+
+## Database
+
+This will be used to choose the Database vendor. MySQL is used by default.
+
+_**DATABASE**_
 
 ## PHP
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a basic LAMP stack environment built using Docker Compose. It consists f
 
 * PHP 7.3
 * Apache 2.4
-* MySQL 5.7
+* MySQL 5.7 or MariaDB 10.3
 * phpMyAdmin
 
 ## Installation
@@ -66,6 +66,12 @@ By default following modules are enabled.
 
 > If you want to enable more modules, just update `./bin/webserver/Dockerfile`. You can also generate a PR and we will merge if seems good for general purpose.
 > You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
+
+## Database
+
+This will be used to choose the Database vendor. MySQL is used by default.
+
+_**DATABASE**_
 
 #### Connect via SSH
 

--- a/bin/mariadb/Dockerfile
+++ b/bin/mariadb/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:10.3

--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -1,5 +1,10 @@
 FROM php:7.3-apache-stretch
 
+# Surpresses debconf complaints of trying to install apt packages interactively
+# https://github.com/moby/moby/issues/4032#issuecomment-192327844
+ 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Update
 RUN apt-get -y update --fix-missing ; \
     apt-get upgrade -y ; \

--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -1,48 +1,51 @@
 FROM php:7.3-apache-stretch
 
-RUN apt-get -y update --fix-missing
-RUN apt-get upgrade -y
+# Update
+RUN apt-get -y update --fix-missing ; \
+    apt-get upgrade -y ; \
+    apt-get --no-install-recommends install -y apt-utils ; \
+    rm -rf /var/lib/apt/lists/*
 
-# Install useful tools
-RUN apt-get -y install apt-utils nano wget dialog
 
-# Install important libraries
-RUN apt-get -y install --fix-missing apt-utils build-essential git curl libcurl3 libcurl3-dev zip openssl
-
-# Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# Install useful tools and install important libaries
+RUN apt-get -y update ; \
+    apt-get -y --no-install-recommends install nano wget dialog libsqlite3-dev libsqlite3-0 ; \
+    apt-get -y --no-install-recommends install mysql-client zlib1g-dev libzip-dev libicu-dev ; \
+    apt-get -y --no-install-recommends install --fix-missing apt-utils build-essential git curl ; \ 
+    apt-get -y --no-install-recommends install --fix-missing libcurl3 libcurl3-dev zip openssl ; \
+    rm -rf /var/lib/apt/lists/* ; \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install xdebug
-RUN pecl install xdebug-2.7.2
-RUN docker-php-ext-enable xdebug
+RUN pecl install xdebug-2.7.2 ; \
+    docker-php-ext-enable xdebug
 
 # Install redis
-RUN pecl install redis-4.0.1
-RUN docker-php-ext-enable redis
+RUN pecl install redis-4.0.1 ; \
+    docker-php-ext-enable redis
 
 # Other PHP7 Extensions
 
-RUN apt-get -y install libsqlite3-dev libsqlite3-0 mysql-client
-RUN docker-php-ext-install pdo_mysql 
-RUN docker-php-ext-install pdo_sqlite
-RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install pdo_mysql ; \
+    docker-php-ext-install pdo_sqlite ; \
+    docker-php-ext-install mysqli ; \
+    docker-php-ext-install curl ; \
+    docker-php-ext-install tokenizer ; \
+    docker-php-ext-install json ; \
+    docker-php-ext-install zip ; \
+    docker-php-ext-install -j$(nproc) intl ; \
+    docker-php-ext-install mbstring ; \
+    docker-php-ext-install gettext
 
-RUN docker-php-ext-install curl
-RUN docker-php-ext-install tokenizer
-RUN docker-php-ext-install json
-
-RUN apt-get -y install zlib1g-dev libzip-dev
-RUN docker-php-ext-install zip
-
-RUN apt-get -y install libicu-dev
-RUN docker-php-ext-install -j$(nproc) intl
-
-RUN docker-php-ext-install mbstring
-RUN docker-php-ext-install gettext
-
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ 
-RUN docker-php-ext-install -j$(nproc) gd
+# Install Freetype 
+RUN apt-get -y update ; \
+    apt-get --no-install-recommends install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev ; \
+    rm -rf /var/lib/apt/lists/* ; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ ; \
+    docker-php-ext-install -j$(nproc) gd
 
 # Enable apache modules
 RUN a2enmod rewrite headers
+
+# Cleanup
+RUN rm -rf /usr/src/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ${VHOSTS_DIR-./config/vhosts}:/etc/apache2/sites-enabled
       - ${LOG_DIR-./logs/apache2}:/var/log/apache2
   mysql:
-    build: ./bin/mysql
+    build: "${DATABASE}"
     container_name: '5.7-mysql'
     restart: 'always'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   webserver:
     build: 
       context: ./bin/webserver
-    container_name: '7.2.x-webserver'
+    container_name: '7.3.x-webserver'
     restart: 'always'
     ports:
       - "${HOST_MACHINE_UNSECURE_HOST_PORT}:80"

--- a/sample.env
+++ b/sample.env
@@ -2,6 +2,10 @@ DOCUMENT_ROOT=./www
 VHOSTS_DIR=./config/vhosts
 APACHE_LOG_DIR=./logs/apache2
 PHP_INI=./config/php/php.ini
+
+# If you want to use mariadb instead of mysql use /bin/mariadb
+DATABASE=/bin/mysql
+
 MYSQL_DATA_DIR=./data/mysql
 MYSQL_LOG_DIR=./logs/mysql
 


### PR DESCRIPTION
* reduced docker webserver images size by ~25%
`webserver                                           shrinked             9d31955f06c1        3 minutes ago       607MB
`
`webserver                    latest               c9d163b77d59        2 days ago         785MB
`

* corrected an typo in docker-compose file referring to wrong php version
* introduce a switch to easily switch to mariadb without changing any file - just edit the .env to fit your needs or add new versions for testing purposes with ease 
* modified readme to reference the new .env database options
* pulled  dpkg to "noninteractive" changes from #39 to reduces complaints during the build process

I hope this is not too much stuff for one PR 💯 