### PR TITLE
Fix "cant logout" bug and security problem for 7.3.x branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
     environment:
       PMA_HOST: mysql
       PMA_PORT: 3306
-      PMA_USER: ${MYSQL_USER}
-      PMA_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}


### PR DESCRIPTION
Varialbes PMA_USER and PMA_PASSWORD according to https://hub.docker.com/r/phpmyadmin/phpmyadmin/ will do next:

1) Open access for EVERYONE under the name of this user, without the need to enter password. You just type mysite.ru:8080 in browser and you already logged with PMA_USER and PMA_PASSWORD credentials. Its very unsecure.

2) You cant logout from phpmyadmin. If PMA_USER and PMA_PASSWORD are set, "logout" button just dont work, only this user will available through phpmyadmin.

So, I think that PMA_USER and PMA_PASSWORD created for situtations when phpmyadmin available only in secure local network. Its not our case.