### PR TITLE
Updated PHP 7.4 Dockerfile to compile GD

### DIFF
--- a/bin/php74/Dockerfile
+++ b/bin/php74/Dockerfile
@@ -61,7 +61,8 @@ RUN apt-get -y update && \
 libjpeg62-turbo-dev \
 libpng-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-configure gd
+    docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg && \
+    docker-php-ext-install gd
 
 # Enable apache modules
 RUN a2enmod rewrite headers


### PR DESCRIPTION
Hi there!

Currently, the image generated using the PHP 7.4 Dockerfile enables GD, but doesn't compile it properly. As such, functions like gd_info() aren't available. I've adjusted things slightly so that those functions will become available.

Thanks!
Mike