### PR TITLE
Allowing multiple versions of the setup to be run at the same time in the same host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   webserver:
     build: 
       context: ./bin/${PHPVERSION}
-    container_name: ${PHPVERSION}
+    container_name: '${COMPOSE_PROJECT_NAME}-${PHPVERSION}'
     restart: 'always'
     ports:
       - "${HOST_MACHINE_UNSECURE_HOST_PORT}:80"
@@ -21,7 +21,7 @@ services:
   database:
     build:
       context: "./bin/${DATABASE}"
-    container_name: 'database'
+    container_name: '${COMPOSE_PROJECT_NAME}-database'
     restart: 'always'
     ports:
       - "127.0.0.1:${HOST_MACHINE_MYSQL_PORT}:3306"
@@ -35,7 +35,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
-    container_name: 'phpmyadmin'
+    container_name: '${COMPOSE_PROJECT_NAME}-phpmyadmin'
     links:
       - database
     environment:
@@ -52,7 +52,7 @@ services:
       - /sessions
       - ${PHP_INI-./config/php/php.ini}:/usr/local/etc/php/conf.d/php-phpmyadmin.ini
   redis:
-    container_name: 'redis'
+    container_name: '${COMPOSE_PROJECT_NAME}-redis'
     image: redis:latest
     ports:
       - "127.0.0.1:${HOST_MACHINE_REDIS_PORT}:6379"

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,9 @@
 # Please Note: 
 # - In PHP Versions <= 7.4 MySQL8 is not supported due to lacking pdo support
 
+# To determine the name of your containers
+COMPOSE_PROJECT_NAME=lamp
+
 # Possible values: php54, php56, php71, php72, php73, php74
 PHPVERSION=php74
 DOCUMENT_ROOT=./www


### PR DESCRIPTION
That way there can be multiple versions of this docker-compose setup running at the same time at the same local machine

By using the variable `COMPOSE_PROJECT_NAME` (https://docs.docker.com/compose/reference/envvars/#compose_project_name) concatenated to the container names, we can have multiple versions of this setup running at the same time.

Otherwise, the second runs will fail because the name already exists - and the user will have to edit the name of the containers manually. By having an environment variable it's more streamlined.