### PR TITLE
Ensure env.sample matches fixes #104

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -24,6 +24,6 @@ HOST_MACHINE_REDIS_PORT=6379
 MYSQL_ROOT_PASSWORD=tiger
 
 # Database settings: Username, password and database name
-MYSQL_USER=docker
-MYSQL_PASSWORD=docker
-MYSQL_DATABASE=docker
+MYSQL_USER=root
+MYSQL_PASSWORD=tiger
+MYSQL_DATABASE=


### PR DESCRIPTION
When following instructions from readme you will end up with incorrect credentials. Using the old root / tiger combo works.