### PR TITLE
Forwarding MYSQL_ROOT_PASSWORD as Server environnement variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${LOG_DIR-./logs/apache2}:/var/log/apache2
     environment:
       PMA_PORT: ${HOST_MACHINE_PMA_PORT}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
   database:
     build:
       context: "./bin/${DATABASE}"

--- a/www/index.php
+++ b/www/index.php
@@ -31,7 +31,7 @@
                                 <li>PHP <?= phpversion(); ?></li>
                                 <li>
                                     <?php
-                                    $link = mysqli_connect("database", "root", "tiger", null);
+                                    $link = mysqli_connect("database", "root", $_ENV['MYSQL_ROOT_PASSWORD'], null);
 
 /* check connection */
                                     if (mysqli_connect_errno()) {

--- a/www/test_db.php
+++ b/www/test_db.php
@@ -1,5 +1,5 @@
 <?php
-$link = mysqli_connect("database", "root", "tiger", null);
+$link = mysqli_connect("database", "root", $_ENV['MYSQL_ROOT_PASSWORD'], null);
 
 if (!$link) {
     echo "Error: Unable to connect to MySQL." . PHP_EOL;

--- a/www/test_db_pdo.php
+++ b/www/test_db_pdo.php
@@ -1,7 +1,7 @@
 <?php
 
 $DBuser = 'root';
-$DBpass = 'tiger';
+$DBpass = $_ENV['MYSQL_ROOT_PASSWORD'];
 $pdo = null;
 
 try{


### PR DESCRIPTION
Mysql MYSQL_ROOT_PASSWORD in .env should be the same in tests files (index.php, test_db.php, test_db_pdo.php)

Make .env variable