### PR TITLE
Enabling the Xdebug in php.ini file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ As of now, we have several different PHP versions. Use appropriate php version a
 * Run the `docker-compose up -d`.
 
 ```shell
-git clone https://github.com/sprintcube/docker-compose-lamp.git
+git clone https://github.com/harshalone/docker-compose-lamp.git
 cd docker-compose-lamp/
 cp sample.env .env
 // modify sample.env as needed

--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -1,3 +1,7 @@
 memory_limit = 256M
 post_max_size = 100M
 upload_max_filesize = 100M
+xdebug.remote_enable=1
+xdebug.remote_host=host.docker.internal
+;The autostart is not convenient because it will be triggered even during AJAX calls
+;xdebug.remote_autostart=1


### PR DESCRIPTION
I cloned the project but  Xdebug wasn't working because the Dockerfile is different for every version and in the one that comes by default, Xdebug is not enabled and not listening to the right IP. 

I think it's better like this ;)