### PR TITLE
Add Calendar extension support

### DIFF
--- a/bin/php74/Dockerfile
+++ b/bin/php74/Dockerfile
@@ -61,6 +61,7 @@ RUN docker-php-ext-install pdo_mysql && \
     docker-php-ext-install -j$(nproc) intl && \
     docker-php-ext-install mbstring && \
     docker-php-ext-install gettext && \
+    docker-php-ext-install calendar && \
     docker-php-ext-install exif
 
 

--- a/bin/php8/Dockerfile
+++ b/bin/php8/Dockerfile
@@ -75,6 +75,7 @@ RUN docker-php-ext-install pdo_mysql && \
     docker-php-ext-install -j$(nproc) intl && \
     docker-php-ext-install mbstring && \
     docker-php-ext-install gettext && \
+    docker-php-ext-install calendar && \
     docker-php-ext-install exif
 
 


### PR DESCRIPTION
These extension resolve the error when use cal_days_in_month(). Without these extension the function not work.