### PR TITLE
added config in docker files

### DIFF
--- a/bin/mariadb106/Dockerfile
+++ b/bin/mariadb106/Dockerfile
@@ -1,1 +1,2 @@
 FROM mariadb:10.6
+COPY *.cnf /etc/mysql/conf.d/my.cnf

--- a/bin/mysql57/Dockerfile
+++ b/bin/mysql57/Dockerfile
@@ -1,1 +1,2 @@
 FROM mysql:5.7
+COPY *.cnf /etc/mysql/conf.d/my.cnf

--- a/bin/mysql8/Dockerfile
+++ b/bin/mysql8/Dockerfile
@@ -1,2 +1,4 @@
 FROM mysql:8
+COPY *.cnf /etc/mysql/conf.d/my.cnf
+
 RUN echo "default-authentication-plugin=mysql_native_password" >> /etc/mysql/my.cnf


### PR DESCRIPTION

Added functionality , to parse *.cnf files to the container 

**Usage**
add a .cnf file to you mysql version of choice and add your custom parameters like eg

```
[mysqld]
max_connections=888
```
save the file and the file bill be copied over after a rebuild `docker-compose up --build`

**Test cases:** 

added a my.cnf file to mysql8 container with a unique value 

`[mysqld]
max_connections=888`

logged in to the mysql container and checked if the config is present in /etc/mysql/mysql.d/my.cnf, config is present and value is also present.

removed the my.cnf file rebuild the mysql image no errors , checked if default mysql config is applied.