### PR TITLE
adds feature #196 ssl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,31 @@
-#  LAMP stack built with Docker Compose
+# LAMP stack built with Docker Compose
 
 ![Landing Page](https://user-images.githubusercontent.com/43859895/141092846-905eae39-0169-4fd7-911f-9ff32c48b7e8.png)
 
-
 A basic LAMP stack environment built using Docker Compose. It consists of the following:
 
-* PHP
-* Apache
-* MySQL
-* phpMyAdmin
-* Redis
+- PHP
+- Apache
+- MySQL
+- phpMyAdmin
+- Redis
 
 As of now, we have several different PHP versions. Use appropriate php version as needed:
 
-* 5.4.x
-* 5.6.x
-* 7.1.x
-* 7.2.x
-* 7.3.x
-* 7.4.x
-* 8.0.x
-* 8.1.x
+- 5.4.x
+- 5.6.x
+- 7.1.x
+- 7.2.x
+- 7.3.x
+- 7.4.x
+- 8.0.x
+- 8.1.x
 
- 
-##  Installation
- 
-* Clone this repository on your local computer
-* configure .env as needed 
-* Run the `docker-compose up -d`.
+## Installation
+
+- Clone this repository on your local computer
+- configure .env as needed
+- Run the `docker-compose up -d`.
 
 ```shell
 git clone https://github.com/sprintcube/docker-compose-lamp.git
@@ -38,31 +36,39 @@ docker-compose up -d
 // visit localhost
 ```
 
-Your LAMP stack is now ready!! You can access it via `http://localhost`. 
+Your LAMP stack is now ready!! You can access it via `http://localhost`.
 
-##  Configuration and Usage
+## Configuration and Usage
 
-### General Information 
+### General Information
+
 This Docker Stack is build for local development and not for production usage.
 
 ### Configuration
+
 This package comes with default configuration options. You can modify them by creating `.env` file in your root directory.
 To make it easy, just copy the content from `sample.env` file and update the environment variable values as per your need.
 
 ### Configuration Variables
+
 There are following configuration variables available and you can customize them by overwritting in your own `.env` file.
 
 ---
+
 #### PHP
+
 ---
+
 _**PHPVERSION**_
-Is used to specify which PHP Version you want to use. Defaults always to latest PHP Version. 
+Is used to specify which PHP Version you want to use. Defaults always to latest PHP Version.
 
 _**PHP_INI**_
-Define your custom `php.ini` modification to meet your requirments. 
+Define your custom `php.ini` modification to meet your requirments.
 
 ---
-#### Apache 
+
+#### Apache
+
 ---
 
 _**DOCUMENT_ROOT**_
@@ -84,15 +90,17 @@ _**APACHE_LOG_DIR**_
 This will be used to store Apache logs. The default value for this is `./logs/apache2`.
 
 ---
+
 #### Database
+
 ---
 
-> For Apple Silicon Users: 
-Please select Mariadb as Database. Oracle doesn't build their SQL Containers for the arm Architecure
+> For Apple Silicon Users:
+> Please select Mariadb as Database. Oracle doesn't build their SQL Containers for the arm Architecure
 
 _**DATABASE**_
 
-Define which MySQL or MariaDB Version you would like to use. 
+Define which MySQL or MariaDB Version you would like to use.
 
 _**MYSQL_INITDB_DIR**_
 
@@ -116,8 +124,8 @@ Apache is configured to run on port 80. So, you can access it via `http://localh
 
 By default following modules are enabled.
 
-* rewrite
-* headers
+- rewrite
+- headers
 
 > If you want to enable more modules, just update `./bin/phpX/Dockerfile`. You can also generate a PR and we will merge if seems good for general purpose.
 > You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
@@ -136,22 +144,22 @@ The installed version of php depends on your `.env`file.
 
 #### Extensions
 
-By default following extensions are installed. 
+By default following extensions are installed.
 May differ for PHP Versions <7.x.x
 
-* mysqli
-* pdo_sqlite
-* pdo_mysql
-* mbstring
-* zip
-* intl
-* mcrypt
-* curl
-* json
-* iconv
-* xml
-* xmlrpc
-* gd
+- mysqli
+- pdo_sqlite
+- pdo_mysql
+- mbstring
+- zip
+- intl
+- mcrypt
+- curl
+- json
+- iconv
+- xml
+- xmlrpc
+- gd
 
 > If you want to install more extension, just update `./bin/webserver/Dockerfile`. You can also generate a PR and we will merge if it seems good for general purpose.
 > You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
@@ -194,7 +202,7 @@ Example:
 #xdebug.idekey=VSCODE
 ```
 
-Xdebug VS Code: you have to install the Xdebug extension "PHP Debug". After installed, go to Debug and create the launch file so that your IDE can listen and work properly. 
+Xdebug VS Code: you have to install the Xdebug extension "PHP Debug". After installed, go to Debug and create the launch file so that your IDE can listen and work properly.
 
 Example:
 
@@ -202,20 +210,20 @@ Example:
 
 ```json
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Listen for Xdebug",
-            "type": "php",
-            "request": "launch",
-            // "port": 9000, // Xdebug 2
-            "port": 9003, // Xdebug 3
-            "pathMappings": {
-                // "/var/www/html": "${workspaceFolder}/www" // if you have opened VSCODE in root folder
-                "/var/www/html": "${workspaceFolder}" // if you have opened VSCODE in ./www folder
-            }
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      // "port": 9000, // Xdebug 2
+      "port": 9003, // Xdebug 3
+      "pathMappings": {
+        // "/var/www/html": "${workspaceFolder}/www" // if you have opened VSCODE in root folder
+        "/var/www/html": "${workspaceFolder}" // if you have opened VSCODE in ./www folder
+      }
+    }
+  ]
 }
 ```
 
@@ -227,15 +235,60 @@ Now, make a breakpoint and run debug.
 
 It comes with Redis. It runs on default port `6379`.
 
+## SSL (HTTPS)
+
+Support for `https` domains is built-in but disabled by default. There are 3 ways you can enable and configure SSL; `https` on `localhost` being the easiest. If you are trying to recreating a testing environment as close as possible to a production environment, any domain name can be supported with more configuration.
+
+**Notice:** For every non-localhost domain name you wish to use `https` on, you will need to modify your computers [hosts file](https://en.wikipedia.org/wiki/Hosts_%28file%29) and point the domain name to `127.0.0.1`. If you fail to do this SSL will not work and you will be routed to the internet every time you try to visit that domain name locally.
+
+### 1) HTTPS on Localhost
+
+To enable `https` on `localhost` (https://localhost) you will need to:
+
+1. Use a tool like [mkcert](https://github.com/FiloSottile/mkcert#installation) to create an SSL certificate for `localhost`:
+   - With `mkcert`, in the terminal run `mkcert localhost 127.0.0.1 ::1`.
+   - Rename the files that were generated `cert.pem` and `cert-key.pem` respectively.
+   - Move these files into your docker setup by placing them in `config/ssl` directory.
+2. Uncomment the `443` vhost in `config/vhosts/default.conf`.
+
+Done. Now any time you turn on your LAMP container `https` will work on `localhost`.
+
+### 2) HTTPS on many Domains with a Single Certificate
+
+If you would like to use normal domain names for local testing, and need `https` support, the simplest solution is an SSL certificate that covers all the domain names:
+
+1. Use a tool like [mkcert](https://github.com/FiloSottile/mkcert#installation) to create an SSL certificate that covers all the domain names you want:
+   - With `mkcert`, in the terminal run `mkcert example.com "*.example.org" myapp.dev localhost 127.0.0.1 ::1` where you replace all the domain names and IP addresses to the ones you wish to support.
+   - Rename the files that were generated `cert.pem` and `cert-key.pem` respectively.
+   - Move these files into your docker setup by placing them in `config/ssl` directory.
+2. Uncomment the `443` vhost in `config/vhosts/default.conf`.
+
+Done. Since you combined all the domain names into a single certificate, the vhost file will support your setup without needing to modify it further. You could add domain specific rules if you wish however. Now any time you turn on your LAMP container `https` will work on all the domains you specified.
+
+### 3) HTTPS on many Domain with Multiple Certificates
+
+If you would like your local testing environment to exactly match your production, and need `https` support, you could create an SSL certificate for every domain you wish to support:
+
+1. Use a tool like [mkcert](https://github.com/FiloSottile/mkcert#installation) to create an SSL certificate that covers the domain name you want:
+   - With `mkcert`, in the terminal run `mkcert [your-domain-name(s)-here]` replacing the bracket part with your domain name.
+   - Rename the files that were generated to something unique like `[name]-cert.pem` and `[name]-cert-key.pem` replacing the bracket part with a unique name.
+   - Move these files into your docker setup by placing them in `config/ssl` directory.
+2. Using the `443` example from the vhost file (`config/vhosts/default.conf`), make new rules that match your domain name and certificate file names.
+
+Done. The LAMP container will auto pull in any SSL certificates in `config/ssl` when it starts. As long as you configure the vhosts file correctly and place the SSL certificates in `config/ssl`, any time you turn on your LAMP container `https` will work on your specified domains.
+
 ## Contributing
-We are happy if you want to create a pull request or help people with their issues. If you want to create a PR, please remember that this stack is not built for production usage, and changes should be good for general purpose and not overspecialized. 
-> Please note that we simplified the project structure from several branches for each php version, to one centralized master branch.  Please create your PR against master branch. 
-> 
-Thank you! 
+
+We are happy if you want to create a pull request or help people with their issues. If you want to create a PR, please remember that this stack is not built for production usage, and changes should be good for general purpose and not overspecialized.
+
+> Please note that we simplified the project structure from several branches for each php version, to one centralized master branch. Please create your PR against master branch.
+>
+> Thank you!
 
 ## Why you shouldn't use this stack unmodified in production
-We want to empower developers to quickly create creative Applications. Therefore we are providing an easy to set up a local development environment for several different Frameworks and PHP Versions. 
+
+We want to empower developers to quickly create creative Applications. Therefore we are providing an easy to set up a local development environment for several different Frameworks and PHP Versions.
 In Production you should modify at a minimum the following subjects:
 
-* php handler: mod_php=> php-fpm
-* secure mysql users with proper source IP limitations
+- php handler: mod_php=> php-fpm
+- secure mysql users with proper source IP limitations

--- a/bin/php54/Dockerfile
+++ b/bin/php54/Dockerfile
@@ -42,11 +42,17 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
 RUN pecl install xdebug-2.4.0RC4 && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
-
 RUN a2enmod rewrite rpaf
 
 EXPOSE 80
+EXPOSE 443
 
 ENTRYPOINT ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/bin/php56/Dockerfile
+++ b/bin/php56/Dockerfile
@@ -28,9 +28,16 @@ RUN docker-php-ext-install curl \
     && pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
 
 EXPOSE 80
+EXPOSE 443
 
 ENTRYPOINT ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/bin/php71/Dockerfile
+++ b/bin/php71/Dockerfile
@@ -42,5 +42,11 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ 
 RUN docker-php-ext-install -j$(nproc) gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers

--- a/bin/php72/Dockerfile
+++ b/bin/php72/Dockerfile
@@ -52,5 +52,11 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ 
 RUN docker-php-ext-install -j$(nproc) gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers

--- a/bin/php73/Dockerfile
+++ b/bin/php73/Dockerfile
@@ -49,6 +49,12 @@ RUN apt-get -y update && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
 

--- a/bin/php74/Dockerfile
+++ b/bin/php74/Dockerfile
@@ -76,6 +76,12 @@ libpng-dev && \
     docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg && \
     docker-php-ext-install gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
 

--- a/bin/php8/Dockerfile
+++ b/bin/php8/Dockerfile
@@ -90,6 +90,12 @@ libpng-dev && \
     docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg && \
     docker-php-ext-install gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
 

--- a/bin/php81/Dockerfile
+++ b/bin/php81/Dockerfile
@@ -89,6 +89,12 @@ libpng-dev && \
     docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg && \
     docker-php-ext-install gd
 
+# Insure an SSL directory exists
+RUN mkdir -p /etc/apache2/ssl
+
+# Enable SSL support
+RUN a2enmod ssl && a2enmod rewrite
+
 # Enable apache modules
 RUN a2enmod rewrite headers
 

--- a/config/vhosts/default.conf
+++ b/config/vhosts/default.conf
@@ -6,3 +6,23 @@
 		AllowOverride all
 	</Directory>
 </VirtualHost>
+
+# Allows HTTPS on localhost. You will need to use mkcert on your local machine
+# to create the `cert.pem` and `cert-key.pem` files, and then place them in the
+# `./config/ssl` directory. You coudl also create certificates for any local
+# testing domain you wish such as `localapp.test`, you will then edit your hosts
+# file to map that domain name to 127.0.0.1 and then configure your vhosts below
+# accordingly:
+#
+# <VirtualHost *:443>
+#     ServerAdmin webmaster@localhost
+#     DocumentRoot ${APACHE_DOCUMENT_ROOT}
+#     ServerName localhost
+# 	<Directory ${APACHE_DOCUMENT_ROOT}>
+# 		AllowOverride all
+# 	</Directory>
+
+#     SSLEngine on
+#     SSLCertificateFile /etc/apache2/ssl/cert.pem
+#     SSLCertificateKeyFile /etc/apache2/ssl/cert-key.pem
+# </VirtualHost>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,19 @@ version: "3"
 
 services:
   webserver:
-    build: 
+    build:
       context: ./bin/${PHPVERSION}
-    container_name: '${COMPOSE_PROJECT_NAME}-${PHPVERSION}'
-    restart: 'always'
+    container_name: "${COMPOSE_PROJECT_NAME}-${PHPVERSION}"
+    restart: "always"
     ports:
       - "${HOST_MACHINE_UNSECURE_HOST_PORT}:80"
       - "${HOST_MACHINE_SECURE_HOST_PORT}:443"
-    links: 
+    links:
       - database
-    volumes: 
-      - ${DOCUMENT_ROOT-./www}:/var/www/html
+    volumes:
+      - ${DOCUMENT_ROOT-./www}:/var/www/html:rw
       - ${PHP_INI-./config/php/php.ini}:/usr/local/etc/php/php.ini
+      - ${SSL_DIR-./config/ssl}:/etc/apache2/ssl/
       - ${VHOSTS_DIR-./config/vhosts}:/etc/apache2/sites-enabled
       - ${LOG_DIR-./logs/apache2}:/var/log/apache2
       - ${XDEBUG_LOG_DIR-./logs/xdebug}:/var/log/xdebug
@@ -27,15 +28,15 @@ services:
       HOST_MACHINE_MYSQL_PORT: ${HOST_MACHINE_MYSQL_PORT}
       XDEBUG_CONFIG: "client_host=host.docker.internal remote_port=${XDEBUG_PORT}"
     extra_hosts:
-       - "host.docker.internal:host-gateway"
+      - "host.docker.internal:host-gateway"
   database:
     build:
       context: "./bin/${DATABASE}"
-    container_name: '${COMPOSE_PROJECT_NAME}-${DATABASE}'
-    restart: 'always'
+    container_name: "${COMPOSE_PROJECT_NAME}-${DATABASE}"
+    restart: "always"
     ports:
       - "127.0.0.1:${HOST_MACHINE_MYSQL_PORT}:3306"
-    volumes: 
+    volumes:
       - ${MYSQL_INITDB_DIR-./config/initdb}:/docker-entrypoint-initdb.d
       - ${MYSQL_DATA_DIR-./data/mysql}:/var/lib/mysql
       - ${MYSQL_LOG_DIR-./logs/mysql}:/var/log/mysql
@@ -45,8 +46,8 @@ services:
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    container_name: '${COMPOSE_PROJECT_NAME}-phpmyadmin'
+    image: phpmyadmin
+    container_name: "${COMPOSE_PROJECT_NAME}-phpmyadmin"
     links:
       - database
     environment:
@@ -60,12 +61,13 @@ services:
       UPLOAD_LIMIT: ${UPLOAD_LIMIT}
       MEMORY_LIMIT: ${MEMORY_LIMIT}
     ports:
-      - '${HOST_MACHINE_PMA_PORT}:80'
-    volumes: 
+      - "${HOST_MACHINE_PMA_PORT}:80"
+      - "${HOST_MACHINE_PMA_SECURE_PORT}:443"
+    volumes:
       - /sessions
       - ${PHP_INI-./config/php/php.ini}:/usr/local/etc/php/conf.d/php-phpmyadmin.ini
   redis:
-    container_name: '${COMPOSE_PROJECT_NAME}-redis'
+    container_name: "${COMPOSE_PROJECT_NAME}-redis"
     image: redis:latest
     ports:
       - "127.0.0.1:${HOST_MACHINE_REDIS_PORT}:6379"

--- a/sample.env
+++ b/sample.env
@@ -11,6 +11,7 @@ APACHE_DOCUMENT_ROOT=/var/www/html
 VHOSTS_DIR=./config/vhosts
 APACHE_LOG_DIR=./logs/apache2
 PHP_INI=./config/php/php.ini
+SSL_DIR=./config/ssl
 
 # PHPMyAdmin
 UPLOAD_LIMIT=512M
@@ -42,6 +43,7 @@ HOST_MACHINE_MYSQL_PORT=3306
 
 # If you already have the port 8080 in use, you can change it (for example if you have PMA)
 HOST_MACHINE_PMA_PORT=8080
+HOST_MACHINE_PMA_SECURE_PORT=8443
 
 # If you already has the port 6379 in use, you can change it (for example if you have Redis)
 HOST_MACHINE_REDIS_PORT=6379


### PR DESCRIPTION
This PR adds support for SSL (HTTPS) in the LAMP server. It was designed to add simple `https` support on `localhost` but can be used for any domain name. 

### HTTPS on Localhost
To use `https://localhost` you will need to:
1. Use a tool like [mkcert](https://github.com/FiloSottile/mkcert#installation) to create an SSL certificate for `localhost`.
    - With `mkcert`, in the terminal run `mkcert localhost 127.0.0.1 ::1`
    - Rename the files `cert.pem` and `cert-key.pem` respectively
    - Move the files into your docker setup by placing them in `config/ssl`
2. You will need to uncomment the `443` vhost in `config/vhosts/default.conf`

### HTTPS with any Domain
1. Follow step 1 from the previous section `HTTPS on Localhost` but for the domain you wish to use locally.
    - You should probably choose different names for the files `cert.pem` and `cert-key.pem`, especially if you plan to add several `https` protected domains.
2. You will need to edit you machines `hosts` file and point the domain(s) to `127.0.0.1`; these domains are meant for testing locally, we don't want your computer to perform a DNS query searching the internet for the domain.
3. You will need to uncomment the `443` vhost in `config/vhosts/default.conf` and modify it to match your domain name and certificate file names.
    - If you have multiple domains on `https (443)` then you will need to create multiple vhost entries for each of those domains.

### Notable Additions by this PR
- Adds an `ssl` folder under `config` for your ssl cert(s)
- Adds the environment variable `SSL_DIR` that points to `./config/ssl`
- Adds the environment variable `HOST_MACHINE_PMA_SECURE_PORT` to hopefully allow `https` access to `phpmyadmin`
    - Currently not working. I could use help with this if anyone is interested.
- Adds this line under `volumes` for the `webserver` in the `docker-compose` file: `- ${SSL_DIR-./config/ssl}:/etc/apache2/ssl/`
    - This is what allows you to place ssl certs in `config/ssl` and have them auto load into the server on startup. 
-  Adds this line under `ports` for the `phpmyadmin` in the `docker-compose` file: `- "${HOST_MACHINE_PMA_SECURE_PORT}:443"`
    - Currently not working. I could use help with this if anyone is interested.