### PR TITLE
Remove localhost from link

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -53,7 +53,7 @@
                         <div class="content">
                             <ul>
                                 <li><a href="/phpinfo.php">phpinfo()</a></li>
-                                <li><a href="http://localhost:<? print $_ENV['PMA_PORT']; ?>">phpMyAdmin</a></li>
+                                <li><a href="//<?= $_SERVER['HTTP_HOST'] ?>:<? print $_ENV['PMA_PORT']; ?>">phpMyAdmin</a></li>
                                 <li><a href="/test_db.php">Test DB Connection with mysqli</a></li>
                                 <li><a href="/test_db_pdo.php">Test DB Connection with PDO</a></li>
                             </ul>


### PR DESCRIPTION
Changed this to HTTP_HOST.  When running this on a remote machine this link won't work.