### PR TITLE
Update repository URLs and dependencies  PHP73/Dockerfile

### DIFF
--- a/bin/php73/Dockerfile
+++ b/bin/php73/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-stretch
+FROM php:7.3-apache-bullseye
 
 # Surpresses debconf complaints of trying to install apt packages interactively
 # https://github.com/moby/moby/issues/4032#issuecomment-192327844
@@ -15,9 +15,9 @@ RUN apt-get -y update --fix-missing && \
 # Install useful tools and install important libaries
 RUN apt-get -y update && \
     apt-get -y --no-install-recommends install nano wget dialog libsqlite3-dev libsqlite3-0 && \
-    apt-get -y --no-install-recommends install mysql-client zlib1g-dev libzip-dev libicu-dev && \
+    apt-get -y --no-install-recommends install mariadb-client zlib1g-dev libzip-dev libicu-dev && \
     apt-get -y --no-install-recommends install --fix-missing apt-utils build-essential git curl && \ 
-    apt-get -y --no-install-recommends install --fix-missing libcurl3 libcurl3-dev zip openssl && \
+    apt-get -y --no-install-recommends install --fix-missing libcurl4 libcurl4-openssl-dev zip openssl && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
Update repository URLs and dependencies:

Due to repository URL changes, this commit updates the following components:

- Base image: Upgraded from '7.3-apache-stretch' to '7.3-apache-bullseye'.
- MySQL client: Replaced with 'mariadb-client'.
- libcurl: Upgraded from 'libcurl3' and 'libcurl3-dev' to 'libcurl4' and 'libcurl4-openssl-dev'.

These changes ensure compatibility with the new repository locations and updated dependencies.
