### PR TITLE
Update README.md with docker compose replacing docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ As of now, we have several different PHP versions. Use appropriate php version a
 
 - Clone this repository on your local computer
 - configure .env as needed
-- Run the `docker-compose up -d`.
+- Run the `docker compose up -d`.
 
 ```shell
 git clone https://github.com/sprintcube/docker-compose-lamp.git
 cd docker-compose-lamp/
 cp sample.env .env
 // modify sample.env as needed
-docker-compose up -d
+docker compose up -d
 // visit localhost
 ```
 
@@ -130,14 +130,14 @@ By default following modules are enabled.
 - headers
 
 > If you want to enable more modules, just update `./bin/phpX/Dockerfile`. You can also generate a PR and we will merge if seems good for general purpose.
-> You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
+> You have to rebuild the docker image by running `docker compose build` and restart the docker containers.
 
 #### Connect via SSH
 
-You can connect to web server using `docker-compose exec` command to perform various operation on it. Use below command to login to container via ssh.
+You can connect to web server using `docker compose exec` command to perform various operation on it. Use below command to login to container via ssh.
 
 ```shell
-docker-compose exec webserver bash
+docker compose exec webserver bash
 ```
 
 ## PHP
@@ -164,7 +164,7 @@ May differ for PHP Versions <7.x.x
 - gd
 
 > If you want to install more extension, just update `./bin/webserver/Dockerfile`. You can also generate a PR and we will merge if it seems good for general purpose.
-> You have to rebuild the docker image by running `docker-compose build` and restart the docker containers.
+> You have to rebuild the docker image by running `docker compose build` and restart the docker containers.
 
 ## phpMyAdmin
 


### PR DESCRIPTION
In README, the commands to build the docker containers suggest using `docker-compose` command. `docker-compose` is now deprecated, as mentioned in https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/

The new and updated command `docker compose` aka `v2` is now used. How to migrate to `v2` is mentioned in https://docs.docker.com/compose/migrate/

closes #265 