### PR TITLE
typo

### DIFF
--- a/dev_build_container.sh
+++ b/dev_build_container.sh
@@ -76,7 +76,7 @@ buildenvfile () {
 
 cat sample.env > ./buildtest/"$buildtarget"-"$version".env
 sed -i "s/COMPOSE_PROJECT_NAME=lamp/COMPOSE_PROJECT_NAME=$buildtarget-buildtest/" ./buildtest/"$buildtarget"-"$version".env
-sed -i "s/PHPVERSION=php8/PHPVERSION=$buildtarget/" ./buildtest/"$buildtarget"-"$version".env
+sed -i "s/PHPVERSION=php83/PHPVERSION=$buildtarget/" ./buildtest/"$buildtarget"-"$version".env
 sed -i "s/DATABASE=mysql8/DATABASE=$version/" ./buildtest/"$buildtarget"-"$version".env
 }
 


### PR DESCRIPTION
sample.env was recently changed to use php83, dev_build_container.sh should reflect the change. I don't know why line 142 was changed. Sorry, I'm new to github.