### PR TITLE
Fix: mysql8 - Unknown variable "default-authentication-plugin"

### DIFF
--- a/bin/mysql8/Dockerfile
+++ b/bin/mysql8/Dockerfile
@@ -1,3 +1,3 @@
 FROM mysql:8
 RUN echo "[mysqld]" >> /etc/mysql/my.cnf
-RUN echo "default-authentication-plugin=mysql_native_password" >> /etc/mysql/my.cnf
+RUN echo "mysql_native_password=ON" >> /etc/mysql/my.cnf


### PR DESCRIPTION
This is a fix for  issue  #277 - The description is below.

### Proposed changes:
Change `default-authentication-plugin=mysql_native_password` to `mysql_native_password=ON` in the mysql8 Dockerfile.

### Describe the bug
* MySQL crashes with the `default-authentication-plugin=mysql_native_password` configuration enabled by default in the Dockerfile for mysql8

### Which Branch / PHP Version are you using ?
* `php83`

### Steps to reproduce
* Use `mysql8` as database

### Expected behavior
* MySQL is supposed to start and run.

### Error message
```
bigbase-mysql8      | 2024-05-12T16:59:48.716026Z 0 [ERROR] [MY-000067] [Server] unknown variable 'default-authentication-plugin=mysql_native_password'.
test-mysql8      | 2024-05-12T16:59:48.717540Z 0 [ERROR] [MY-010119] [Server] Aborting
test-mysql8      | 2024-05-12T16:59:50.739542Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.4.0)  MySQL Community Server - GPL.
test-mysql8      | 2024-05-12T16:59:50.739616Z 0 [System] [MY-015016] [Server] MySQL Server - end.
test-mysql8 exited with code 0
```
**This just repeats until I kill the container**

### Desktop (please complete the following information):
* OS: `Windows`
* Docker Version: `26.0.0`

### Additional context
* Related to issue #273 
* But I was unable to reproduce the issue described there with or without my Pull Request, and I tried every version of mariadb included.
* I suspect that the issue there is that version of mariadb was changed without cleaning the data folder.
